### PR TITLE
278 - styled ui, added tutorial, made logout a button, not a tab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "pace-c",
+  "name": "pace-c-4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {}

--- a/src/front-end/src/App.css
+++ b/src/front-end/src/App.css
@@ -16,6 +16,14 @@ a {
   text-decoration: none;
 }
 
+p1 {
+  font-size: 1.15em;
+}
+
+p3 {
+  font-size: 0.75em;
+}
+
 .mentorship-form {
   border: solid black;
   padding: 25px;
@@ -28,10 +36,41 @@ a {
   margin: 30px;
 }
 
+.MentorSuggested {
+  border: solid black;
+  padding: 25px;
+  margin: 30px;
+}
+
+.MentorAccepted {
+  border: solid black;
+  padding: 25px;
+  margin: 30px;
+}
+
+.MentorTutorial {
+  border: solid black;
+  padding: 25px;
+  margin: 30px;
+}
+
+#logout_button {
+  position:absolute;
+  right:0;
+}
+
 .MentorForm {
   border: solid black;
   padding: 25px;
   margin: 30px;
+}
+
+p2 {
+  font-size: 1.15em;
+}
+
+p4 {
+  font-size: 0.75em;
 }
 
 .NextButton-InMentor {

--- a/src/front-end/src/components/MenteeForm.js
+++ b/src/front-end/src/components/MenteeForm.js
@@ -35,6 +35,7 @@ class MenteeForm extends Component {
       nameInput: name,
       emailInput: email,
     };
+
     emailjs.send(
       'gmail',
       'template_kfjkdm4',

--- a/src/front-end/src/components/MentorAccepted.js
+++ b/src/front-end/src/components/MentorAccepted.js
@@ -35,7 +35,15 @@ class MentorAccepted extends Component {
       <>
         <Form>
           <h1>
-            <center>These are your accepted mentees:</center>
+            <center>Accepted Mentees:</center>
+            <p4>
+              <center>
+                <i>
+                  Below you can interact and view details about each accepted
+                  mentee
+                </i>
+              </center>
+            </p4>
           </h1>
         </Form>
         <br />

--- a/src/front-end/src/components/MentorAccepted.js
+++ b/src/front-end/src/components/MentorAccepted.js
@@ -38,10 +38,7 @@ class MentorAccepted extends Component {
             <center>Accepted Mentees:</center>
             <p4>
               <center>
-                <i>
-                  Below you can interact and view details about each accepted
-                  mentee
-                </i>
+                <i>Below you can view details about each accepted mentee</i>
               </center>
             </p4>
           </h1>

--- a/src/front-end/src/components/MentorHome.js
+++ b/src/front-end/src/components/MentorHome.js
@@ -47,14 +47,19 @@ class MentorHome extends Component {
         >
           Accepted Mentees
         </Button>
+        {/* replace what's in square brackets [] w/ info from DB */}
+        <Button
+          type="primary"
+          htmlType="button"
+          id="logout_button"
+          // href="[insert logout page path here]"
+        >
+          logout
+        </Button>
+
         <Route path="/Auth/SuggestedMentees" component={MentorSuggested} />
         <Route path="/Auth/MentorAccepted" component={MentorAccepted} />
         <Route path="/Auth/MentorTutorial" component={MentorTutorial} />
-
-        {/* replace what's in square brackets [] w/ info from DB */}
-        <Button onClick={this.onLogout} type="primary" htmlType="button">
-          Logout
-        </Button>
       </>
     );
   }

--- a/src/front-end/src/components/MentorHome.js
+++ b/src/front-end/src/components/MentorHome.js
@@ -52,6 +52,7 @@ class MentorHome extends Component {
           type="primary"
           htmlType="button"
           id="logout_button"
+          onClick={this.onLogout}
           // href="[insert logout page path here]"
         >
           logout

--- a/src/front-end/src/components/MentorSuggested.js
+++ b/src/front-end/src/components/MentorSuggested.js
@@ -35,7 +35,15 @@ class MentorSuggested extends Component {
       <>
         <Form>
           <h1>
-            <center>These are your suggested mentees:</center>
+            <center>Suggested Mentees:</center>
+            <p3>
+              <center>
+                <i>
+                  After a mentee is accepted, you can view your accepted mentee
+                  on the accepted mentees page
+                </i>
+              </center>
+            </p3>
           </h1>
         </Form>
         <br />

--- a/src/front-end/src/components/MentorTutorial.js
+++ b/src/front-end/src/components/MentorTutorial.js
@@ -7,11 +7,49 @@ class MentorTutorial extends Component {
   render() {
     return (
       <>
-        <Form>
-          <h1>
-            <center>Write tutorial here</center>
-          </h1>
-        </Form>
+        <div className="Login">
+          <Form>
+            <h1>
+              <center>Welcome To Mentor Match&apos;s Mentor Tutorial!</center>
+            </h1>
+            <h3>
+              <center>
+                This is the mentor tutorial page where you can learn how to see
+                and interact with:
+                <ul>
+                  <li>
+                    <i>Suggested Mentees</i>
+                  </li>
+                  <li>
+                    <i>Accepted Mentees</i>
+                  </li>
+                </ul>
+              </center>
+            </h3>
+            <h3>
+              <b>Suggested Mentees:</b>
+            </h3>
+            <p1>
+              The suggested mentees tab is located on the top of the page. On
+              the suggested mentee page you will be able to view all of you
+              suggested mentees and details about each mentee. To accept a
+              mentee click on the green check mark button below the
+              mentee&apos;s information. To decline a mentee click on the red X
+              button below the mentee&apos;s information.
+            </p1>
+            {/* eslint-disable-next-line react/self-closing-comp */}
+            <p></p>
+            <h3>
+              <b>Accepted Mentees:</b>
+            </h3>
+            <p2>
+              The accepted mentees tab is also located on the top of the page
+              next to the suggested mentee tab. On the accepted mentees tab you
+              can view the information of all mentees that have been accepted
+              from the suggested mentees tab.
+            </p2>
+          </Form>
+        </div>
       </>
     );
   }

--- a/src/front-end/src/components/MentorTutorial.js
+++ b/src/front-end/src/components/MentorTutorial.js
@@ -31,7 +31,7 @@ class MentorTutorial extends Component {
             </h3>
             <p1>
               The suggested mentees tab is located on the top of the page. On
-              the suggested mentee page you will be able to view all of you
+              the suggested mentee page you will be able to view all of your
               suggested mentees and details about each mentee. To accept a
               mentee click on the green check mark button below the
               mentee&apos;s information. To decline a mentee click on the red X


### PR DESCRIPTION
Styled the pages for the mentor UI, made the logout ”tab” an actual button and positioned it to always be in the top left corner and added a tutorial explaining how to use the mentor ui.