### PR TITLE
Fix tab switching delay

### DIFF
--- a/src/front-end/src/components/MentorHome.js
+++ b/src/front-end/src/components/MentorHome.js
@@ -5,7 +5,6 @@ import {
   SolutionOutlined,
   UsergroupAddOutlined,
 } from '@ant-design/icons';
-// import { Route } from 'react-router-dom';
 import MentorSuggested from './MentorSuggested';
 import MentorAccepted from './MentorAccepted';
 import MentorTutorial from './MentorTutorial/MentorTutorial';

--- a/src/front-end/src/components/MentorHome.js
+++ b/src/front-end/src/components/MentorHome.js
@@ -1,46 +1,57 @@
 import React, { Component } from 'react';
-import { Button } from 'antd';
-import { Route } from 'react-router-dom';
+import { Tabs } from 'antd';
+import {
+  CarryOutOutlined,
+  SolutionOutlined,
+  UsergroupAddOutlined,
+} from '@ant-design/icons';
+// import { Route } from 'react-router-dom';
 import MentorSuggested from './MentorSuggested';
 import MentorAccepted from './MentorAccepted';
 import MentorTutorial from './MentorTutorial/MentorTutorial';
+
+const { TabPane } = Tabs;
 
 // eslint-disable-next-line react/prefer-stateless-function
 class MentorHome extends Component {
   render() {
     return (
       <>
-        <Button
-          type="primary"
-          htmlType="button"
-          id="mentorHome"
-          href="/my-account/mentor-tutorial"
-        >
-          Mentor Tutorial
-        </Button>
-        <Button
-          type="primary"
-          htmlType="button"
-          id="suggestedMentees"
-          href="/my-account/suggested-mentees"
-        >
-          Suggested Mentees
-        </Button>
-        <Button
-          type="primary"
-          htmlType="button"
-          id="acceptedMentees"
-          href="/my-account/accepted-mentees"
-        >
-          Accepted Mentees
-        </Button>
-
-        <Route
-          path="/my-account/suggested-mentees"
-          component={MentorSuggested}
-        />
-        <Route path="/my-account/accepted-mentees" component={MentorAccepted} />
-        <Route path="/my-account/mentor-tutorial" component={MentorTutorial} />
+        <Tabs defaultActiveKey="1">
+          <TabPane
+            key="1"
+            tab={
+              <span>
+                <SolutionOutlined />
+                Mentor Tutorial
+              </span>
+            }
+          >
+            <MentorTutorial />
+          </TabPane>
+          <TabPane
+            key="2"
+            tab={
+              <span>
+                <UsergroupAddOutlined />
+                Suggested Mentees
+              </span>
+            }
+          >
+            <MentorSuggested />
+          </TabPane>
+          <TabPane
+            key="3"
+            tab={
+              <span>
+                <CarryOutOutlined />
+                Accepted Mentees
+              </span>
+            }
+          >
+            <MentorAccepted />
+          </TabPane>
+        </Tabs>
       </>
     );
   }


### PR DESCRIPTION
From what I was able to test out, the problem seemed to be with routing and the auth page, since auth was constantly checking whether the logged in user had verified their email every time the button was clicked to navigate to the next page. While it was routing, the user would be null for a slight second, before it grabbed the user's information (hence why it showed the unverified email page). To by pass routing completely, I used ant design's 'Tab' component (and added icons with it to try and enhance how it looks).